### PR TITLE
Do not wait for body, if it is skipped explicitly.

### DIFF
--- a/lib/rspec/cramp/mock_response.rb
+++ b/lib/rspec/cramp/mock_response.rb
@@ -14,14 +14,18 @@ module RSpec
           stopping = false
           deferred_body = @body
           chunks = []
-          deferred_body.each do |chunk|
-            chunks << chunk unless stopping
+          check = lambda do
             if chunks.count >= max_chunks
               @body = chunks
               stopping = true
               block.call if block
               EM.next_tick { EM.stop }
             end            
+          end
+          check.call
+          deferred_body.each do |chunk|
+            chunks << chunk unless stopping
+            check.call
           end
         end
       end


### PR DESCRIPTION
Hello, Martin,

First of all, thank you for a useful gem.

I've added support for `:max_chunks => 0`, so now one can easily test those actions, that render nothing on connection (currently a timeout exception is being raised), e. g.

``` ruby
it 'should establish connection' do
  get('/sse', :max_chunks => 0).should respond_with :status => :ok
end
```
